### PR TITLE
Update openapi_php.php

### DIFF
--- a/demo/php/openapi_php.php
+++ b/demo/php/openapi_php.php
@@ -67,6 +67,6 @@ function headerJoin($headers = [])
 function signature($httpMethod, $contentMD5, $contentType, $headerString, $resource)
 {
     $stringSection = array($httpMethod, $contentMD5, $contentType, $headerString, $resource);
-    $stringSection = implode($stringSection, "\n");
+    $stringSection = implode("\n", $stringSection);
     return strtoupper(md5($stringSection));
 }


### PR DESCRIPTION
签名函数(signature) 中使用的的 implode 方法参数顺序有写反了